### PR TITLE
Download using proxy settings from ENV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +846,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-webpki",
+ "socks",
  "url",
  "webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-ureq = "2.6"
+ureq = {version = "2.6", features = ["socks-proxy"] }
 dirs-next = "2.0.0"
 flate2 = "1.0"
 fs4 = "0.6.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,11 @@ impl Download {
 }
 
 fn download_binary(url: &str) -> Result<Vec<u8>> {
-    let response = ureq::get(url).call()?;
+    let response = ureq::builder()
+        .try_proxy_from_env(true)
+        .build()
+        .get(url)
+        .call()?;
 
     let status_code = response.status();
 


### PR DESCRIPTION
This PR enables `ureq` to use proxy settings from ENV, it solves lots of pain in network restricted environments.